### PR TITLE
Fix recent additions for GCC build

### DIFF
--- a/Source/Core/DolphinWX/ConfigVR.h
+++ b/Source/Core/DolphinWX/ConfigVR.h
@@ -8,6 +8,7 @@
 #include "DolphinWX/InputConfigDiag.h"
 
 class InputConfig;
+class VRDialog;
 
 class CConfigVR : public wxDialog
 {
@@ -82,7 +83,7 @@ class VRDialog : public wxDialog
 public:
 	VRDialog(CConfigVR* const parent);
 
-	void VRDialog::SetButtonID(int from_button);
+	void SetButtonID(int from_button);
 	//void UpdateGUI();
 
 private:


### PR DESCRIPTION
It wouldn't build for me without the forward declaration and `-fpermissive` requires namespace to not be declared within class definitions. 
