### PR TITLE
Implement missing GLX Offscreen rendering functions

### DIFF
--- a/Source/Core/DolphinWX/GLInterface/GLX.cpp
+++ b/Source/Core/DolphinWX/GLInterface/GLX.cpp
@@ -114,6 +114,81 @@ bool cInterfaceGLX::Create(void *window_handle)
 	return true;
 }
 
+// Create offscreen rendering window and its secondary OpenGL context
+// This is used for the normal rendering thread with asynchronous timewarp
+bool cInterfaceGLX::CreateOffscreen()
+{
+	int glxMajorVersion, glxMinorVersion;
+
+	// attributes for a single buffered visual in RGBA format with at least
+	// 8 bits per color
+	int attrListSgl[] = {GLX_RGBA, GLX_RED_SIZE, 8,
+		GLX_GREEN_SIZE, 8,
+		GLX_BLUE_SIZE, 8,
+		None};
+
+	// attributes for a double buffered visual in RGBA format with at least
+	// 8 bits per color
+	int attrListDbl[] = {GLX_RGBA, GLX_DOUBLEBUFFER,
+		GLX_RED_SIZE, 8,
+		GLX_GREEN_SIZE, 8,
+		GLX_BLUE_SIZE, 8,
+		None };
+
+	int attrListDefault[] = {
+		GLX_RGBA,
+		GLX_RED_SIZE, 1,
+		GLX_GREEN_SIZE, 1,
+		GLX_BLUE_SIZE, 1,
+		GLX_DOUBLEBUFFER,
+		None };
+
+	dpy_offscreen = XOpenDisplay(nullptr);
+	int screen = DefaultScreen(dpy_offscreen);
+
+	glXQueryVersion(dpy_offscreen, &glxMajorVersion, &glxMinorVersion);
+	NOTICE_LOG(VIDEO, "glX-Version %d.%d", glxMajorVersion, glxMinorVersion);
+
+	// Get an appropriate visual
+	vi = glXChooseVisual(dpy_offscreen, screen, attrListDbl);
+	if (vi == nullptr)
+	{
+		vi = glXChooseVisual(dpy_offscreen, screen, attrListSgl);
+		if (vi != nullptr)
+		{
+			ERROR_LOG(VIDEO, "Only single buffered visual!");
+		}
+		else
+		{
+			vi = glXChooseVisual(dpy_offscreen, screen, attrListDefault);
+			if (vi == nullptr)
+			{
+				ERROR_LOG(VIDEO, "Could not choose visual (glXChooseVisual)");
+				return false;
+			}
+		}
+	}
+	else
+	{
+		NOTICE_LOG(VIDEO, "Got double buffered visual!");
+	}
+
+	// Create a GLX context.
+	ctx_offscreen = glXCreateContext(dpy_offscreen, vi, nullptr, GL_TRUE);
+	if (!ctx_offscreen)
+	{
+		PanicAlert("Unable to create GLX context.");
+		return false;
+	}
+
+	XWindow.Initialize(dpy_offscreen);
+
+	s_backbuffer_width  = 640;
+	s_backbuffer_height = 480;
+
+	return true;
+}
+
 bool cInterfaceGLX::MakeCurrent()
 {
 	bool success = glXMakeCurrent(dpy, win, ctx);
@@ -125,9 +200,28 @@ bool cInterfaceGLX::MakeCurrent()
 	return success;
 }
 
+bool cInterfaceGLX::MakeCurrentOffscreen()
+{
+	bool success;
+	if (dpy_offscreen && win_offscreen && ctx_offscreen)
+		success = glXMakeCurrent(dpy_offscreen, win_offscreen, ctx_offscreen) ? true : false;
+	else
+		success = glXMakeCurrent(dpy,win,ctx) ? true : false;
+	if (success)
+	{
+		// Grab the swap interval function pointer
+		glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC)GLInterface->GetFuncAddress("glXSwapIntervalSGI");
+	}
+	return success;
+}
+
 bool cInterfaceGLX::ClearCurrent()
 {
 	return glXMakeCurrent(dpy, None, nullptr);
+}
+
+bool cInterfaceGLX::ClearCurrentOffscreen() {
+	return glXMakeCurrent(dpy_offscreen, None, nullptr);
 }
 
 
@@ -141,5 +235,16 @@ void cInterfaceGLX::Shutdown()
 		XCloseDisplay(dpy);
 		ctx = nullptr;
 	}
+}
+
+void cInterfaceGLX::ShutdownOffscreen()
+{
+	XWindow.DestroyXWindow();
+		if (ctx_offscreen)
+		{
+			glXDestroyContext(dpy_offscreen, ctx_offscreen);
+			XCloseDisplay(dpy_offscreen);
+			ctx_offscreen = nullptr;
+		}
 }
 

--- a/Source/Core/DolphinWX/GLInterface/GLX.h
+++ b/Source/Core/DolphinWX/GLInterface/GLX.h
@@ -14,9 +14,9 @@ class cInterfaceGLX : public cInterfaceBase
 {
 private:
 	cX11Window XWindow;
-	Display *dpy;
-	Window win;
-	GLXContext ctx;
+	Display *dpy, *dpy_offscreen;
+	Window win, win_offscreen;
+	GLXContext ctx, ctx_offscreen;
 	XVisualInfo *vi;
 public:
 	friend class cX11Window;
@@ -24,7 +24,12 @@ public:
 	void Swap() override;
 	void* GetFuncAddress(const std::string& name) override;
 	bool Create(void *window_handle);
+	bool CreateOffscreen();
 	bool MakeCurrent() override;
+	bool MakeCurrentOffscreen();
 	bool ClearCurrent() override;
+	bool ClearCurrentOffscreen();
+
 	void Shutdown() override;
+	void ShutdownOffscreen();
 };

--- a/Source/Core/VideoBackends/OGL/main.cpp
+++ b/Source/Core/VideoBackends/OGL/main.cpp
@@ -208,6 +208,7 @@ bool VideoBackend::InitializeOtherThread(void *window_handle, std::thread *video
 // Run from the graphics thread
 void VideoBackend::Video_Prepare()
 {
+	// TODO: Make this check if it needs offscreen or not (aka, if VR is enabled)
 	GLInterface->MakeCurrentOffscreen();
 
 	g_renderer = new Renderer;


### PR DESCRIPTION
I found out what the issue was! The CreateOffScreen functions were unimplemented for GLX, and were left as a {return true;} from the GLInterface.h file (really? return success if it's inimplemented? whyyyyy). With this, I... well, get the same crash that I get on the master branch, which is a segfault (presumably unrelated to VR!)

These GLX definitions are rough, and were simply copies from the typical definitions applied to seperate offscreen contexts, with some modifications whereever it seemed neccesary. I need to test them more, but I can't really until there's an upstream merge that fixes whatever's causing that segfault, and ofcourse my DK2 arrives.

So yeah! EGL, and a handful of other definitions need to be implemented. But I think the GLInterface.h file should at the very least have a prototype definition of {return false;}, since if that's the only function called, _it definately didn't succeed_.
